### PR TITLE
Loading skeletons

### DIFF
--- a/app/live/layout.tsx
+++ b/app/live/layout.tsx
@@ -1,0 +1,19 @@
+import Image from "next/image";
+import type React from "react";
+
+export default function Layout({children}: { children: React.ReactNode }) {
+
+    return <div className="space-y-6">
+        <div className="flex items-center gap-3">
+            <Image
+                src="/images/icon.svg"
+                alt="Ikarus Festival Logo"
+                width={36}
+                height={36}
+                className="h-[3em] w-auto align-middle"
+            />
+            <h1 className="text-2xl font-bold">Live Tracker</h1>
+        </div>
+        { children }
+    </div>
+}

--- a/app/live/loading.tsx
+++ b/app/live/loading.tsx
@@ -1,0 +1,30 @@
+import {Skeleton} from "@/components/ui/skeleton";
+import {Card} from "@/components/ui/card";
+
+export default function Loading() {
+
+    return <div className="grid gap-4 items-start">
+        <Card className="p-4">
+            <div className="flex flex-row w-full h-full space-x-4">
+                <Skeleton className="h-6 w-[50%]"/>
+                <Skeleton className="h-24 w-[50%]"/>
+            </div>
+        </Card>
+        {[0, 1, 2, 3].map(() => <Card className="p-4">
+            <div className="flex flex-row w-full h-full space-x-4">
+                <div className="flex flex-col h-full w-[50%]">
+                    <Skeleton className="h-6 w-full mb-2"/>
+                    <Skeleton className="h-24 w-full "/>
+                </div>
+                <div className="flex flex-col h-full flex-1">
+                    <Skeleton className="h-20 w-full mb-2" />
+                    <div className="flex flex-row w-full justify-center">
+                        <Skeleton className="h-10 w-10 rounded-full"/>
+                        <Skeleton className="h-10 w-10 rounded-full"/>
+                        <Skeleton className="h-10 w-10 rounded-full"/>
+                    </div>
+                </div>
+            </div>
+        </Card>)}
+    </div>
+}

--- a/app/live/loading.tsx
+++ b/app/live/loading.tsx
@@ -10,7 +10,7 @@ export default function Loading() {
                 <Skeleton className="h-24 w-[50%]"/>
             </div>
         </Card>
-        {[0, 1, 2, 3].map(() => <Card className="p-4">
+        {[0, 1, 2, 3].map((index) => <Card key={index} className="p-4">
             <div className="flex flex-row w-full h-full space-x-4">
                 <div className="flex flex-col h-full w-[50%]">
                     <Skeleton className="h-6 w-full mb-2"/>

--- a/app/live/page.tsx
+++ b/app/live/page.tsx
@@ -54,19 +54,5 @@ export default async function LivePage() {
         }
     })
 
-    return (
-        <div className="space-y-6">
-            <div className="flex items-center gap-3">
-                <Image
-                    src="/images/icon.svg"
-                    alt="Ikarus Festival Logo"
-                    width={36}
-                    height={36}
-                    className="h-[3em] w-auto align-middle"
-                />
-                <h1 className="text-2xl font-bold">Live Tracker</h1>
-            </div>
-            <LiveTracker stages={stagesWithCurrentActs} locations={locations} userId={user.id}/>
-        </div>
-    )
+    return <LiveTracker stages={stagesWithCurrentActs} locations={locations} userId={user.id}/>
 }

--- a/app/profile/layout.tsx
+++ b/app/profile/layout.tsx
@@ -1,0 +1,24 @@
+import Image from "next/image";
+import {SignOutButton} from "@/components/auth/sign-out-button";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+
+    return (
+        <div className="space-y-8">
+            <div className="flex items-center gap-3">
+                <Image
+                    src="/images/icon.svg"
+                    alt="Ikarus Festival Logo"
+                    width={36}
+                    height={36}
+                    className="h-[3em] w-auto align-middle"
+                />
+                <h1 className="text-2xl font-bold">Mein Profil</h1>
+                <SignOutButton/>
+            </div>
+            <div className="w-full flex flex-col justify-center pt-10">
+                { children }
+            </div>
+        </div>
+    )
+}

--- a/app/profile/loading.tsx
+++ b/app/profile/loading.tsx
@@ -1,0 +1,16 @@
+import {Skeleton} from "@/components/ui/skeleton";
+
+export default function Loading() {
+
+    return <div className="mx-16 space-y-10">
+        <div className="flex flex-col items-center space-y-4">
+            <Skeleton className="h-24 w-24 rounded-full"/>
+            <Skeleton className="w-full h-12 mx-auto"/>
+        </div>
+        <Skeleton className="w-full h-16 mx-auto"/>
+        <div className="justify-center items-center flex flex-col space-y-6 py-4">
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+        </div>
+    </div>
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -2,9 +2,7 @@ import {createClient} from "@/lib/supabase/server"
 import {redirect} from "next/navigation"
 import {ProfileForm} from "@/components/profile/profile-form"
 import {updateProfile} from "@/actions/profile"
-import {SignOutButton} from "@/components/auth/sign-out-button"
 import {Profile} from "@/lib/supabase/database.types";
-import Image from "next/image";
 
 export default async function ProfilePage() {
     const supabase = await createClient()
@@ -18,22 +16,5 @@ export default async function ProfilePage() {
 
     const {data: profile} = await supabase.from("profiles").select().eq("id", user.id).single<Profile>()
 
-    return (
-        <div className="space-y-8">
-            <div className="flex items-center gap-3">
-                <Image
-                    src="/images/icon.svg"
-                    alt="Ikarus Festival Logo"
-                    width={36}
-                    height={36}
-                    className="h-[3em] w-auto align-middle"
-                />
-                <h1 className="text-2xl font-bold">Mein Profil</h1>
-                <SignOutButton/>
-            </div>
-            <div className="w-full flex flex-col justify-center pt-10">
-                <ProfileForm profile={profile} updateProfile={updateProfile}/>
-            </div>
-        </div>
-    )
+    return <ProfileForm profile={profile} updateProfile={updateProfile}/>
 }

--- a/app/timetable/layout.tsx
+++ b/app/timetable/layout.tsx
@@ -1,0 +1,19 @@
+import Image from "next/image";
+import type React from "react";
+
+export default function Layout({children}: { children: React.ReactNode }) {
+
+    return <div className="space-y-6 flex-col flex">
+        <div className="flex items-center gap-3">
+            <Image
+                src="/images/icon.svg"
+                alt="Ikarus Festival Logo"
+                width={36}
+                height={36}
+                className="h-[3em] w-auto align-middle"
+            />
+            <h1 className="text-2xl font-bold">Timetable</h1>
+        </div>
+        { children }
+    </div>
+}

--- a/app/timetable/loading.tsx
+++ b/app/timetable/loading.tsx
@@ -1,0 +1,21 @@
+import {Skeleton} from "@/components/ui/skeleton";
+
+export default function Loading() {
+
+    return <div className="flex flex-col space-y-6">
+        <div className="flex flex-row w-full space-x-4 pt-2">
+            <Skeleton className="h-10 flex-1"/>
+            <Skeleton className="h-10 flex-1"/>
+            <Skeleton className="h-10 flex-1"/>
+        </div>
+        <div className="flex flex-wrap gap-4">
+            {[...Array(7)].map((_, index) => {
+                const width = Math.floor(Math.random() * 100) + 100;
+                console.log(`Width for skeleton ${index}: ${width}px`);
+                return <Skeleton key={index} className={`h-10`} style={{width}}/>
+            })}
+        </div>
+        <Skeleton className="h-52 w-full"/>
+        <Skeleton className="h-64 w-full"/>
+    </div>
+}

--- a/app/timetable/page.tsx
+++ b/app/timetable/page.tsx
@@ -2,7 +2,6 @@ import {createClient} from "@/lib/supabase/server"
 import {redirect} from "next/navigation"
 import {TimetableView} from "@/components/timetable/timetable-view"
 import {getFavorites} from "@/actions/favorites"
-import Image from "next/image"
 
 export default async function TimetablePage() {
     const supabase = await createClient()
@@ -51,19 +50,5 @@ export default async function TimetablePage() {
         {name: "Sonntag", date: "2023-05-28"},
     ]
 
-    return (
-        <div className="space-y-6 flex-col flex">
-            <div className="flex items-center gap-3">
-                <Image
-                    src="/images/icon.svg"
-                    alt="Ikarus Festival Logo"
-                    width={36}
-                    height={36}
-                    className="h-[3em] w-auto align-middle"
-                />
-                <h1 className="text-2xl font-bold">Timetable</h1>
-            </div>
-            <TimetableView days={days} stages={stages} acts={acts} favorites={favorites}/>
-        </div>
-    )
+    return <TimetableView days={days} stages={stages} acts={acts} favorites={favorites}/>
 }


### PR DESCRIPTION
Add loading skeletons to the timetable, live and profile page that are displayed while the real data is fetched from the backend in order to reduce loading time of page (time between click on navbar and actual switching to the page)